### PR TITLE
feat: add right-click prevention functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-datepicker": "^8.2.1",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
+        "react-dnd-touch-backend": "^16.0.1",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
         "react-redux": "^9.2.0",
@@ -3212,6 +3213,16 @@
       "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
       "license": "MIT",
       "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
+    "node_modules/react-dnd-touch-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-16.0.1.tgz",
+      "integrity": "sha512-NonoCABzzjyWGZuDxSG77dbgMZ2Wad7eQiCd/ECtsR2/NBLTjGksPUx9UPezZ1nQ/L7iD130Tz3RUshL/ClKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
         "dnd-core": "^16.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-datepicker": "^8.2.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
+    "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,16 +3,25 @@ import "./App.css";
 import FormBuilderPage from "./pages/FormBuilderPage";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
+import { TouchBackend } from "react-dnd-touch-backend";
 import { Provider } from "react-redux";
 import { store } from "./redux/app/store";
+import { RightClickProvider } from "./contexts/rightClickContexts";
+const isMobile =
+  /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
+const Backend = isMobile ? TouchBackend : HTML5Backend;
 function App() {
   return (
     <>
-      <DndProvider backend={HTML5Backend}>
-        <Provider store={store}>
-          <FormBuilderPage />
-        </Provider>
-      </DndProvider>
+      <RightClickProvider>
+        <DndProvider backend={Backend}>
+          <Provider store={store}>
+            <FormBuilderPage />
+          </Provider>
+        </DndProvider>
+      </RightClickProvider>
     </>
   );
 }

--- a/src/components/canvas/Canvas.jsx
+++ b/src/components/canvas/Canvas.jsx
@@ -14,8 +14,9 @@ import DraggableComponent from "./DraggableComponent";
 import CanvasHeader from "./CanvasHeader";
 import useCanvas from "../../hooks/useCanvas";
 import useFormHandle from "../../hooks/useFormHandler";
+// import { generateJSXCode } from "../../lib/generateJsx";
 const Canvas = () => {
-  const {isLeftSideBarOpen,isRightSideBarOpen}=useFormHandle()
+  const { isLeftSideBarOpen, isRightSideBarOpen } = useFormHandle();
 
   // const dispatch = useDispatch();
   // const { components, selectedComponent } = useSelector(
@@ -28,10 +29,9 @@ const Canvas = () => {
   const [hoveredIndex, setHoveredIndex] = useState(null);
   useEffect(() => {
     if (components && components?.length) {
-      console.log(components, " components");
-      console.log(isRightSideBarOpen+" isRightSideBarOpen")  
-      console.log(isLeftSideBarOpen+" isLeftSideBarOpen")
-    
+      // Example Usage
+      // const generatedComponents  = generateJSXCode(components);
+      // console.log("Generated Form JSON:", JSON.stringify(generatedComponents , null, 2));
     }
   }, [components]);
   const [{ isOverCanvas }, dropCanvas] = useDrop(() => ({
@@ -48,6 +48,7 @@ const Canvas = () => {
       isOver: !!monitor.isOver(),
     }),
   }));
+
   // const [{ isOverElement }, dropElement] = useDrop({
   //   accept: "FORM_ELEMENT",
   //   drop: (item) => console.log("Dropped inside element"),
@@ -128,17 +129,14 @@ const Canvas = () => {
       return "col-span-12";
     }
   }
-  
+
   return (
     <div className="grid grid-cols-12 w-screen  justify-center absolute top-0 left-0 bg-gray-100 min-h-screen">
-      {isLeftSideBarOpen &&
-            <div className="bg-gray-900 col-span-12 md:col-span-2 h-screen hidden md:block"></div>
-}
+      {isLeftSideBarOpen && (
+        <div className="bg-gray-900 col-span-12 md:col-span-2 h-screen hidden md:block"></div>
+      )}
       <div
-        className={`bg-white ${
-          calculateCanvasLength()
-        } min-h-screen p-6 border border-gray-300`}
-
+        className={`bg-white ${calculateCanvasLength()} min-h-screen p-6 border border-gray-300`}
         ref={dropCanvas}
         // onDrop={handleDrop}
         // onDragOver={handleDragOver}
@@ -226,7 +224,7 @@ const Canvas = () => {
           </pre>
         )}
       </div>
-{/* {!isRightSideBarOpen &&<div className="bg-gray-900 col-span-12 md:col-span-2 h-screen hidden md:block"></div>
+      {/* {!isRightSideBarOpen &&<div className="bg-gray-900 col-span-12 md:col-span-2 h-screen hidden md:block"></div>
 } */}
     </div>
   );

--- a/src/contexts/rightClickContexts.jsx
+++ b/src/contexts/rightClickContexts.jsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+// Create context
+export const RightClickContext = createContext();
+
+
+
+// Provider component
+export const RightClickProvider = ({ children }) => {
+  const [isRightClickDisabled, setIsRightClickDisabled] = useState(true);
+
+  useEffect(() => {
+    const handleContextMenu = (e) => {
+      if (isRightClickDisabled) {
+        e.preventDefault();
+      }
+    };
+
+    document.addEventListener('contextmenu', handleContextMenu);
+
+    return () => {
+      document.removeEventListener('contextmenu', handleContextMenu);
+    };
+  }, [isRightClickDisabled]);
+
+  // Functions to enable or disable right click
+  const enableRightClick = () => setIsRightClickDisabled(false);
+  const disableRightClick = () => setIsRightClickDisabled(true);
+  const toggleRightClick = () => setIsRightClickDisabled(prev => !prev);
+
+  const value = {
+    isRightClickDisabled,
+    enableRightClick,
+    disableRightClick,
+    toggleRightClick
+  };
+
+  return (
+    <RightClickContext.Provider value={value}>
+      {children}
+    </RightClickContext.Provider>
+  );
+};

--- a/src/hooks/useRightClick.js
+++ b/src/hooks/useRightClick.js
@@ -1,0 +1,6 @@
+// Custom hook to use the right click context
+import { RightClickContext } from "../contexts/rightClickContexts";
+
+export const useRightClick = () => {
+  return useContext(RightClickContext);
+};

--- a/src/lib/generateJsx.js
+++ b/src/lib/generateJsx.js
@@ -1,0 +1,41 @@
+import { formElements } from "../components/DragableElementConfig/FormElements";
+import { renderToString } from "react-dom/server";
+export const generateJSXCode = (components) => {
+    console.log("Generating JSX for components:", components);
+  
+    return components.map((component) => {
+      const FormComponent = formElements[component.type]?.formComponent;
+  
+      if (!FormComponent) {
+        console.warn(`Component not found for type: ${component.type}`);
+        return {
+          id: component.id,
+          type: component.type,
+          error: "Component not found",
+        };
+      }
+  
+      const jsxElement = <FormComponent key={component.id} elementInstance={component} />;
+  
+      return {
+        id: component.id,
+        type: component.type,
+        jsxString: renderToString(jsxElement), // ✅ Convert JSX to a string before logging
+      };
+    });
+  };
+  
+// export const generateJSXCode = (components) => {
+//   console.log("components in generateJSXCode are ", components);
+
+//     return components.map((component) => {
+//       const FormComponent = formElements[component.type]?.formComponent
+
+//       if (!FormComponent) {
+//         console.warn(`Component not found for type: ${component.type}`);
+//         return null;
+//       }
+
+//       return <FormComponent key={component.id} elementInstance={component} />;
+//     });
+// };


### PR DESCRIPTION
- Create RightClickContext for managing contextmenu behavior

- Implement RightClickProvider to allow app-wide control

- Integrate provider in App component root

- Maintain device detection for appropriate DnD backend

This change provides a centralized way to disable right-clicking

throughout the application while allowing drag and drop for both

mobile and touch devices.